### PR TITLE
Firewalld Support

### DIFF
--- a/roles/security/tasks/fail2ban.yml
+++ b/roles/security/tasks/fail2ban.yml
@@ -12,3 +12,6 @@
   copy: src=fail2ban/jail.conf dest=/etc/fail2ban/jail.conf owner=root group=root mode=0644
   notify:
     - restart fail2ban
+
+- name: Security | fail2ban | Start the fail2ban service
+  service: name=fail2ban enabled=yes state=started

--- a/roles/security/tasks/firewalld.yml
+++ b/roles/security/tasks/firewalld.yml
@@ -1,0 +1,7 @@
+# file: roles/security/tasks/firewalld.yml
+
+- name: Security | firewalld | Make sure firewalld is installed
+  yum: name=firewalld state=present
+
+- name: Security | firewalld | Start the firewalld service
+  service: name=firewalld enabled=yes state=started

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -1,3 +1,4 @@
 - include: fail2ban.yml
 - include: rkhunter.yml
 - include: lynis.yml
+- include: firewalld.yml


### PR DESCRIPTION
Right now snackpack leaves the droplet without any firewall rules loaded. This installs, enables, and starts firewalld, which sets up some basic firewall rules. We can/should lock this down even more later on. :door: :fire: 
