### PR TITLE
fprintd: Disable fingerprint authentication

### DIFF
--- a/roles/security/tasks/fprintd.yml
+++ b/roles/security/tasks/fprintd.yml
@@ -1,0 +1,14 @@
+- name: fprintd | Remove the fingerprint reader service
+  yum: name=libfprint state=absent
+  tags:
+  - security
+  - auth
+  - fingerprint
+
+- name: fprintd | Update the pam system-auth configuration
+  command: /usr/sbin/authconfig --disablefingerprint --update
+  changed_when: False
+  tags:
+  - security
+  - auth
+  - fingerprint


### PR DESCRIPTION
:hand:  I don't use this anywhere, so I don't want it getting dbus activated all of the time by pam. :-1: 

We could make it configurable if you actually want a host with it enabled… 
