### PR TITLE
security: Enable Privacy Extensions for Stateless Address Autoconfiguration in IPv6

### DIFF
--- a/roles/security/tasks/ipv6.yml
+++ b/roles/security/tasks/ipv6.yml
@@ -1,0 +1,10 @@
+# https://tools.ietf.org/html/rfc4941
+- name: ipv6 | Enable Privacy Extensions (RFC 4941)
+  sysctl: name="net.ipv6.conf.{{ item }}.use_tempaddr" value=2 sysctl_set=yes state=present reload=yes
+  with_items:
+    - "{{ hostvars[inventory_hostname].ansible_default_ipv6.interface }}"
+    - default
+    - all
+  tags:
+    - security
+    - ipv6

--- a/roles/security/tasks/main.yml
+++ b/roles/security/tasks/main.yml
@@ -12,3 +12,4 @@
 - include: fprintd.yml
 - include: suricata.yml
 - include: firefox.yml
+- include: ipv6.yml


### PR DESCRIPTION
https://tools.ietf.org/html/rfc4941
http://ipv6int.net/systems/linux-ipv6.html
http://ipv6-test.com/
