### PR TITLE
All the bits to get narcissus running again.

### DIFF
--- a/inventory/inventory
+++ b/inventory/inventory
@@ -11,6 +11,12 @@ computer01      ansible_ssh_host=104.131.96.144
 [nagios]
 computer01      ansible_ssh_host=104.131.96.144
 
+[narcissus]
+pencil          ansible_ssh_host=129.21.39.186 ansible_ssh_user=root
+
+[mirrors]
+ganon           ansible_ssh_host=129.21.171.98 ansible_ssh_user=root
+
 # This is a meta group just so nagios knows who to monitor
 [monitored:children]
 dynamic

--- a/playbooks/threebean/narcissus.yml
+++ b/playbooks/threebean/narcissus.yml
@@ -1,0 +1,10 @@
+---
+- name: setup the log sender on mirrors
+  hosts: mirrors
+  roles:
+  - narcissus/sender
+
+- name: narcissus stuff for pencil
+  hosts: narcissus
+  roles:
+  - narcissus/server

--- a/playbooks/threebean/site.yml
+++ b/playbooks/threebean/site.yml
@@ -39,15 +39,15 @@
   vars_files:
   - vars/global.yml
   roles:
-#  - role: nagios/nrpe/site
-#    site: narcissus.rc.rit.edu
-#    target: narcissus
-#    path: /map/
-#  - role: nagios/nrpe/websocket
-#    name: narcissus
-#    address: "ws://narcissus.rc.rit.edu:9000"
-#    topic: http_geojson
-#    timeout: 4
+  - role: nagios/nrpe/site
+    site: narcissus.rc.rit.edu
+    target: narcissus
+    path: /map/
+  - role: nagios/nrpe/websocket
+    name: narcissus
+    address: "ws://narcissus.rc.rit.edu:9998"
+    topic: http_geojson
+    timeout: 4
   - role: nagios/nrpe/site
     site: threebean.org
     target: widget

--- a/roles/development/files/bin/nosy.py
+++ b/roles/development/files/bin/nosy.py
@@ -13,7 +13,7 @@ import subprocess
 import re
 
 
-FILE_REGEX = re.compile(r'(py|rst|css|txt|html|rb|feature|README|yml|conf|ini|wsgi)$')
+FILE_REGEX = re.compile(r'(py|rst|css|txt|html|rb|feature|README|yml|conf|ini|wsgi|cfg)$')
 STAT_INTERVAL = .25 # seconds
 CRAWL_INTERVAL = 10 # seconds
 

--- a/roles/development/files/bin/nosy.py
+++ b/roles/development/files/bin/nosy.py
@@ -13,7 +13,7 @@ import subprocess
 import re
 
 
-FILE_REGEX = re.compile(r'(py|rst|css|txt|html|rb|feature|README)$')
+FILE_REGEX = re.compile(r'(py|rst|css|txt|html|rb|feature|README|yml|conf|ini|wsgi)$')
 STAT_INTERVAL = .25 # seconds
 CRAWL_INTERVAL = 10 # seconds
 

--- a/roles/development/tasks/main.yml
+++ b/roles/development/tasks/main.yml
@@ -17,6 +17,7 @@
   - fedpkg
   - fedora-packager
   - redhat-rpm-config
+  - libxslt-devel  # For building lxml in a venv
   tags:
   - development
 

--- a/roles/narcissus/sender/files/narcissus-log-tailer.sh
+++ b/roles/narcissus/sender/files/narcissus-log-tailer.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This will be publishing logs locally at 5672.
+# That needs to be locked down with iptables so that only pencil.rc.rit.edu can
+# connect.
+
+while [ "1" -eq "1" ] ; do
+    tail \
+        -F /var/log/lighttpd/access.log \
+        -F /var/log/lighttpd/clamav.mirrors.rit.edu.access.log \
+         2>&1 | \
+        /usr/bin/narcissus-zeromq-source --targets=tcp://0.0.0.0:5672
+done

--- a/roles/narcissus/sender/files/narcissus-sender.service
+++ b/roles/narcissus/sender/files/narcissus-sender.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Narcissus Log Sending Script
+After=network.target
+Documentation=https://github.com/ralphbean/narcissus
+
+[Service]
+ExecStart=/usr/local/bin/narcissus-log-tailer.sh
+Type=simple
+User=nobody
+Group=nobody
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/narcissus/sender/handlers/main.yml
+++ b/roles/narcissus/sender/handlers/main.yml
@@ -1,0 +1,10 @@
+- name: reload systemd
+  command: systemctl daemon-reload
+  when: ansible_distribution_major_version != '6'
+
+- name: restart narcissus sender
+  command: systemctl restart narcissus-sender
+  when: ansible_distribution_major_version != '6'
+
+- name: save iptables
+  command: iptables-save

--- a/roles/narcissus/sender/tasks/main.yml
+++ b/roles/narcissus/sender/tasks/main.yml
@@ -10,6 +10,7 @@
   copy: >
     src=narcissus-log-tailer.sh
     dest=/usr/local/bin/narcissus-log-tailer.sh
+    mode=0755
   tags: narcissus
   notify: restart narcissus sender
 

--- a/roles/narcissus/sender/tasks/main.yml
+++ b/roles/narcissus/sender/tasks/main.yml
@@ -1,0 +1,54 @@
+- name: Install packages
+  yum: name={{item}} state=latest
+  with_items:
+  - python-narcissus-common
+  - libselinux-python
+  tags: narcissus
+  notify: restart narcissus sender
+
+- name: Copy our tailing script
+  copy: >
+    src=narcissus-log-tailer.sh
+    dest=/usr/local/bin/narcissus-log-tailer.sh
+  tags: narcissus
+  notify: restart narcissus sender
+
+- name: Copy over a systemd service file for the sender
+  copy: >
+      src=narcissus-sender.service
+      dest=/usr/lib/systemd/system/narcissus-sender.service
+  tags: narcissus
+  when: ansible_distribution_major_version != '6'
+  notify:
+  - reload systemd
+  - restart narcissus sender
+
+- name: Check if port 5672 is managed by iptables
+  shell: iptables -L | grep -q "Let in pencil for narcissus"
+  register: check_allow_narcissus
+  ignore_errors: yes
+  changed_when: no
+  always_run: yes
+  tags: narcissus
+
+- name: Let in pencil on port 5672
+  command: >
+    iptables -A INPUT -p tcp -m tcp --dport 5672
+    -s "{{ hostvars['pencil']['ansible_ssh_host'] }}"
+    -m comment --comment "Let in pencil for narcissus" -j ACCEPT
+  when: check_allow_narcissus.rc != 0
+  notify: save iptables
+  tags: narcissus
+
+- name: Keep out everyone else on port 5672
+  command: >
+    iptables -A INPUT -p tcp -m tcp --dport 5672
+    -m comment --comment "Keep out everyone else" -j REJECT
+  when: check_allow_narcissus.rc != 0
+  notify: save iptables
+  tags: narcissus
+
+- name: Set log tailer service to start
+  service: name=narcissus-sender state=running enabled=yes
+  when: ansible_distribution_major_version != '6'
+  tags: narcissus

--- a/roles/narcissus/server/files/narcissus-hub.service
+++ b/roles/narcissus/server/files/narcissus-hub.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Narcissus message processing daemon
+After=network.target
+Documentation=https://github.com/ralphbean/narcissus
+
+[Service]
+ExecStart=/usr/bin/moksha-hub /etc/narcissus.ini
+Type=simple
+User=nobody
+Group=nobody
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/roles/narcissus/server/files/narcissus.conf
+++ b/roles/narcissus/server/files/narcissus.conf
@@ -1,0 +1,25 @@
+WSGISocketPrefix run/wsgi
+WSGIRestrictSignal Off
+WSGIPythonOptimize 1
+
+<VirtualHost narcissus.rc.rit.edu:80>
+    # TODO -- figure out how to point at all those resources if necessary...
+    #Alias /static /usr/lib/python2.7/site-packages/narcissus.app/widgetstatic/
+
+    WSGIDaemonProcess narcissus user=apache maximum-requests=1000 display-name=narcissus processes=2 threads=2
+
+    WSGIScriptAlias / /var/www/narcissus.wsgi
+
+    <Location />
+        WSGIProcessGroup narcissus
+        <IfModule mod_authz_core.c>
+            # Apache 2.4
+            Require all granted
+        </IfModule>
+        <IfModule !mod_authz_core.c>
+             # Apache 2.2
+            Order deny,allow
+            Allow from all
+        </IfModule>
+    </Location>
+</VirtualHost>

--- a/roles/narcissus/server/files/narcissus.wsgi
+++ b/roles/narcissus/server/files/narcissus.wsgi
@@ -1,0 +1,23 @@
+#-*- coding: UTF-8 -*-
+
+import logging, sys, os
+logging.basicConfig(stream=sys.stderr)
+
+from moksha.wsgi.middleware import make_moksha_middleware
+from moksha.common.lib.helpers import get_moksha_appconfig
+
+from tw2.core.middleware import make_middleware
+
+from narcissus.app.routes import app as application
+from narcissus.app.routes import load_production_config
+
+production_filename = "/etc/narcissus.ini"
+if os.path.exists(production_filename):
+    config = load_production_config(production_filename)
+else:
+    # Load development.ini
+    config = get_moksha_appconfig()
+
+# Wrap the inner wsgi app with our middlewares
+application.wsgi_app = make_moksha_middleware(application.wsgi_app, config)
+application.wsgi_app = make_middleware(application.wsgi_app)

--- a/roles/narcissus/server/handlers/main.yml
+++ b/roles/narcissus/server/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart httpd
+  command: apachectl graceful

--- a/roles/narcissus/server/handlers/main.yml
+++ b/roles/narcissus/server/handlers/main.yml
@@ -1,2 +1,8 @@
 - name: restart httpd
   command: apachectl graceful
+
+- name: restart narcissus-hub
+  command: systemctl restart narcissus-hub
+
+- name: reload systemd
+  command: systemctl daemon-reload

--- a/roles/narcissus/server/tasks/main.yml
+++ b/roles/narcissus/server/tasks/main.yml
@@ -1,0 +1,44 @@
+- name: Install packages
+  yum: name={{item}} state=latest
+  with_items:
+  - python-narcissus-app
+  - libselinux-python
+  tags: narcissus
+  notify: restart httpd
+
+- name: Copy over httpd conf file for narcissus wsgi app
+  copy: >
+      src=narcissus.conf
+      dest=/etc/httpd/conf.d/narcissus.conf
+  tags: narcissus
+  notify: restart httpd
+
+- name: Copy over mod_wsgi script for the narcissus app
+  copy: >
+      src=narcissus.wsgi
+      dest=/var/www/narcissus.wsgi
+  tags: narcissus
+  notify: restart httpd
+
+- name: Copy over config file shared by hub and apache
+  template: >
+      src=narcissus.ini
+      dest=/etc/narcissus.ini
+  tags: narcissus
+  notify:
+  - restart httpd
+  #- restart moksha-hub
+
+- name: Make a directory for moksha config
+  file: dest=/etc/moksha state=directory
+  tags: narcissus
+  notify:
+  - restart httpd
+  #- restart moksha-hub
+
+- name: Symlink the config to another name
+  file: src=/etc/narcissus.ini dest=/etc/moksha/production.ini state=link
+  tags: narcissus
+  notify:
+  - restart httpd
+  #- restart moksha-hub

--- a/roles/narcissus/server/tasks/main.yml
+++ b/roles/narcissus/server/tasks/main.yml
@@ -1,10 +1,15 @@
 - name: Install packages
   yum: name={{item}} state=latest
   with_items:
+  - python-narcissus-hub
   - python-narcissus-app
   - libselinux-python
+  - python-moksha-hub
+  - GeoIP
   tags: narcissus
-  notify: restart httpd
+  notify:
+  - restart httpd
+  - restart narcissus-hub
 
 - name: Copy over httpd conf file for narcissus wsgi app
   copy: >
@@ -27,18 +32,37 @@
   tags: narcissus
   notify:
   - restart httpd
-  #- restart moksha-hub
+  - restart narcissus-hub
 
 - name: Make a directory for moksha config
   file: dest=/etc/moksha state=directory
   tags: narcissus
   notify:
   - restart httpd
-  #- restart moksha-hub
+  - restart narcissus-hub
 
 - name: Symlink the config to another name
   file: src=/etc/narcissus.ini dest=/etc/moksha/production.ini state=link
   tags: narcissus
   notify:
   - restart httpd
-  #- restart moksha-hub
+  - restart narcissus-hub
+
+- name: Copy over narcissus-hub systemd service file
+  copy: >
+      src=narcissus-hub.service
+      dest=/usr/lib/systemd/system/narcissus-hub.service
+  tags: narcissus
+  notify:
+  - reload systemd
+  - restart narcissus-hub
+
+- name: Update our GeoIP databases from maxmind
+  command: geoipupdate
+  tags: narcissus
+  notify:
+  - restart narcissus-hub
+
+- name: Set the narcissus hub service to start
+  service: name=narcissus-hub state=running enabled=yes
+  tags: narcissus

--- a/roles/narcissus/server/tasks/main.yml
+++ b/roles/narcissus/server/tasks/main.yml
@@ -59,6 +59,9 @@
 
 - name: Update our GeoIP databases from maxmind
   command: geoipupdate
+  register: geoipupdate
+  changed_when: geoipupdate.rc == 0
+  ignore_errors: yes
   tags: narcissus
   notify:
   - restart narcissus-hub

--- a/roles/narcissus/server/templates/narcissus.ini
+++ b/roles/narcissus/server/templates/narcissus.ini
@@ -13,6 +13,7 @@ moksha.livesocket = True
 moksha.livesocket.backend = websocket
 moksha.livesocket.reconnect_interval = 5000
 moksha.livesocket.websocket.port = 9998
+moksha.livesocket.websocket.host = narcissus.rc.rit.edu
 
 zmq_enabled = True
 #zmq_strict = True

--- a/roles/narcissus/server/templates/narcissus.ini
+++ b/roles/narcissus/server/templates/narcissus.ini
@@ -1,0 +1,20 @@
+[app:main]
+
+debug = False
+host = narcissus.rc.rit.edu
+port = 80
+
+moksha.domain = narcissus.rc.rit.edu
+
+moksha.notifications = True
+moksha.socket.notify = True
+
+moksha.livesocket = True
+moksha.livesocket.backend = websocket
+moksha.livesocket.reconnect_interval = 5000
+moksha.livesocket.websocket.port = 9998
+
+zmq_enabled = True
+#zmq_strict = True
+zmq_publish_endpoints = tcp://*:11981
+zmq_subscribe_endpoints = tcp://127.0.0.1:11981,tcp://{{hostvars['ganon']['ansible_ssh_host']}}:5672


### PR DESCRIPTION
Running at http://narcissus.rc.rit.edu
- There's a narcissus-hub service running under systemd.  You can watch
  the logs with journalctl.
- The webapp is running under mod_wsgi
- _If_ mirrors was on rhel7, the log sender would be running under systemd
  too.. but instead its in a tmux session like a chump.

There's a new bug somewhere down in python-txws or python-txzmq that was
causing hiccups in the websocket server code.  I hacked it out in
/usr/lib/python2.7/site-packages, but it still needs to be reasoned about and
patched upstream... (which I'll try to do next week)
