### PR TITLE
Make kill-py.sh faster

### DIFF
--- a/roles/development/files/bin/kill-pyc.sh
+++ b/roles/development/files/bin/kill-pyc.sh
@@ -1,5 +1,2 @@
 #!/bin/bash
-
-find . -name "*.egg*" -exec rm -r {} \;
-find . -name "__pycache__" -exec rm -r {} \;
-find . -name "*.pyc" -exec rm {} \;
+find . -name "*.py[co]" -delete -or -name "__pycache__" -delete -or -name "*.egg*" -delete


### PR DESCRIPTION
By reducing the find commands to one query, should make this command 40-50% faster.

Also the `-delete` option means it's possible for this to work on whitespace-containing paths.
