### PR TITLE
Rely on the `closed_at` field rather than the `updated_on` one

### DIFF
--- a/roles/development/files/bin/make-changelog.py
+++ b/roles/development/files/bin/make-changelog.py
@@ -125,7 +125,7 @@ def get_pull_requests_pagure(project, since):
     requests = []
     for request in body.get('requests', []):
         req_update = arrow.get(
-            request.get('updated_on', request['date_created'])
+            request.get('closed_at', request['date_created'])
         )
         if req_update > commit_date:
             requests.append([request['id'], request['title']])


### PR DESCRIPTION
For a closed PR, these two should be the same but while we are sure
`closed_at` won't change, we can't ensure at 100% the same for `updated_on`
so by relying on `closed_at` we are safer.
